### PR TITLE
Adjust make command to remove composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ```
  $ git clone -b gridstack https://github.com/nextcloud/dashboard.git
  $ cd dashboard
- $ make composer npm
+ $ make npm
 ```
 
 


### PR DESCRIPTION
As composer does not exist anymore:
```
$ make composer npm
make: *** No rule to make target 'composer'.  Stop.
```